### PR TITLE
replace timer with message if stream is completed

### DIFF
--- a/src/views/StreamDetails.tsx
+++ b/src/views/StreamDetails.tsx
@@ -125,14 +125,19 @@ export default function StreamDetails() {
     const updateCountDown = async () => {
         if (stream?.stop) {
             await sleep(1000)
-            setCountdown(
-                formatDuration(
-                    intervalToDuration({
-                        start: new Date().getTime(),
-                        end: stream.stop
-                    })
+            const now = new Date().getTime()
+            if (now < stream.stop) {
+                setCountdown(
+                    formatDuration(
+                        intervalToDuration({
+                            start: now,
+                            end: stream.stop
+                        })
+                    )
                 )
-            )
+            } else {
+                setCountdown("Stream completed")
+            }
         }
     }
 


### PR DESCRIPTION
The stream details timer keeps running, counting up after the stream is complete. This patch replaces it with a message to that effect.